### PR TITLE
Simplify `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/build
-/util/genGlFunctionLoader/build
-/src/generated
+**/build
+**/generated


### PR DESCRIPTION
This is just a suggestion. I _hate_ modifying\* the `.gitignore` file, so I try to be as generic as possible.

*<rant> Far too many merge requests at work involve modifying the `.gitignore` file as well as performing actual work and I rarely agree with the changes to the `.gitignore` file. For example, people like to be overly specific about the files they want to ignore: `xyz.zip`. I don't care what that `zip` file is named, it should never be committed to the repository because it is a `zip` file!

The less we have to change it, the less we have to worry about polluting our merge requests and potentially causing (trivial) conflicts. </rant>
